### PR TITLE
Using [] should give the same result than the accessor

### DIFF
--- a/lib/hubspot/resource.rb
+++ b/lib/hubspot/resource.rb
@@ -98,7 +98,7 @@ module Hubspot
     end
 
     def [](name)
-      @changes[name] || @properties[name]
+      @changes[name] || @properties.dig(name, 'value')
     end
 
     def reload
@@ -238,7 +238,7 @@ module Hubspot
       singleton_class.instance_eval do
         keys.each do |k|
           # Define a getter
-          define_method(k) { @changes[k.to_sym] || @properties.dig(k, "value") }
+          define_method(k) { @changes[k.to_sym] || @properties.dig(k, 'value') }
 
           # Define a setter
           define_method("#{k}=") do |v|
@@ -257,7 +257,7 @@ module Hubspot
         # Call the new setter
         return send(method_name, arguments[0])
       elsif @properties.key?(method_name)
-        return @properties[method_name]
+        return @properties[method_name]['value']
       else
         super
       end

--- a/spec/lib/hubspot/resource_spec.rb
+++ b/spec/lib/hubspot/resource_spec.rb
@@ -51,4 +51,44 @@ RSpec.describe Hubspot::Resource do
       end
     end
   end
+
+  describe '#[]' do
+    context 'using new' do
+      let(:resource) { described_class.new(properties) }
+      let(:properties) { { id: 1, firstname: 'John', lastname: 'Wayne' } }
+
+      it { expect(resource[:firstname]).to eq 'John' }
+      it { expect(resource['lastname']).to eq 'Wayne' }
+      it { expect(resource[:middlename]).to be nil }
+    end
+
+    context 'using from_result' do
+      let(:resource) { described_class.from_result({ properties: properties }) }
+      let(:properties) { { id: { 'value' => 1 }, firstname: { 'value' => 'John' }, lastname: { 'value' => 'Wayne' } } }
+
+      it { expect(resource[:firstname]).to eq 'John' }
+      it { expect(resource['lastname']).to eq 'Wayne' }
+      it { expect(resource[:middlename]).to be nil }
+    end
+  end
+
+  describe '#adding_accessors' do
+    describe 'getters' do
+      context 'using new' do
+        let(:resource) { described_class.new(properties) }
+        let(:properties) { { id: 1, firstname: 'John', lastname: 'Wayne' } }
+
+        it { expect(resource.firstname).to eq 'John' }
+        it { expect(resource.lastname).to eq 'Wayne' }
+      end
+
+      context 'using from_result' do
+        let(:resource) { described_class.from_result({ properties: properties }) }
+        let(:properties) { { id: { 'value' => 1 }, firstname: { 'value' => 'John' }, lastname: { 'value' => 'Wayne' } } }
+
+        it { expect(resource.firstname).to eq 'John' }
+        it { expect(resource.lastname).to eq 'Wayne' }
+      end
+    end
+  end
 end


### PR DESCRIPTION
Currently, this is what happens
```ruby
contact = Hubspot::Contact.find(id)
contact[:firstname]
# => {"value"=>"Bruce", "versions"=>[redacted]} 
contact.firstname
# => "Bruce"
```
Which is already inconsistent but how about this?
 ```ruby
contact = Hubspot::Contact.new(firstname: 'Bruce')
contact[:firstname]
# => 'Bruce'
contact.firstname
# => "Bruce"
```

This PR fixes this by having `#[]` always giving the value.

Upstream PR: https://github.com/adimichele/hubspot-ruby/pull/218